### PR TITLE
make-darker-theme

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -14,7 +14,7 @@ html {
 body {
     width: 100%;
     height: 100vh;
-    background-color: #FDD935;
+    background-color: #4e4a3a;
 }
 
 .btn {


### PR DESCRIPTION
/* 
  Thiết lập kiểu cho phần tử <body> của trang web.

  - width: 100%; 
    Đặt chiều rộng của phần tử <body> là 100% của chiều rộng của phần tử chứa nó (thường là chiều rộng của cửa sổ trình duyệt).
  
  - height: 100vh; 
    Đặt chiều cao của phần tử <body> là 100% chiều cao của cửa sổ trình duyệt (viewport height). 
    "vh" là đơn vị chiều cao của viewport, 1vh bằng 1% chiều cao của cửa sổ trình duyệt.

  - background-color: #4e4a3a; 
    Đặt màu nền của phần tử <body> là một màu nâu xám (#4e4a3a). 
    Mã màu này được biểu thị bằng mã hex, với các giá trị màu đỏ, xanh lá cây và xanh dương (RGB) cụ thể.
*/